### PR TITLE
Add API route for user registration with password hashing and data st…

### DIFF
--- a/app/api/register/route.js
+++ b/app/api/register/route.js
@@ -1,17 +1,32 @@
 import { NextResponse } from "next/server";
-//import bcrypt from "bcrypt";
+import bcrypt from "bcrypt";
 import fs from "fs/promises";
 import path from "path";
 const fakeDBPath = path.join(process.cwd(), "fakeDB", "db.json");
 export async function POST(request) {
   try {
     const objFromFrontEnd = await request.json();
-      console.log("***************************************");
-    console.log("Received object from Front-end in POST function:", objFromFrontEnd);
+    console.log("***************************************");
+    console.log(
+      "Received object from Front-end in POST function:",
+      objFromFrontEnd
+    );
+    console.log("*****************  Hashing password_salt   **************************");
+    const salt = await bcrypt.genSalt(10);
+    const hashedPassword = await bcrypt.hash(objFromFrontEnd.password, salt);
+
+    const userWithHashedPassword = {
+      ...objFromFrontEnd,
+      password: hashedPassword,
+    };
     const dbContent = await fs.readFile(fakeDBPath, "utf-8");
     const parsedData = dbContent ? JSON.parse(dbContent) : { users: [] };
-    parsedData.users.push(objFromFrontEnd);
-    await fs.writeFile(fakeDBPath, JSON.stringify(parsedData, null, 2), "utf-8");
+    parsedData.users.push(userWithHashedPassword);
+    await fs.writeFile(
+      fakeDBPath,
+      JSON.stringify(parsedData, null, 2),
+      "utf-8"
+    );
     return NextResponse.json({
       success: true,
       message: "User data successfully saved in db.json",


### PR DESCRIPTION
…orage

- Create a POST route for user registration.
- Hash the password using `bcrypt` with a salt of 10 rounds before saving it.
- Store the hashed password and user data in a local JSON database (`db.json`).
- If the data is successfully saved, respond with a success message.
- Handle errors and return a failure message if the process encounters an issue.